### PR TITLE
remove OpenCodeGraph prefix from exported type names

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ _Status: alpha_
 - [Source code](https://github.com/sourcegraph/opencodegraph)
 - [Docs](https://opencodegraph.org)
 - License: [Apache 2.0](LICENSE)
+
+## TODOs
+
+- rename opencodegraphdata -> something shorter

--- a/client/browser/src/background/background.main.ts
+++ b/client/browser/src/background/background.main.ts
@@ -1,7 +1,7 @@
 import '../shared/polyfills'
 // ^^ import polyfills first
 import { createClient } from '@opencodegraph/client'
-import { type OpenCodeGraphProvider } from '@opencodegraph/provider'
+import { type Provider } from '@opencodegraph/provider'
 import helloWorldProvider from '@opencodegraph/provider-hello-world'
 import linksProvider from '@opencodegraph/provider-links'
 import prometheusProvider from '@opencodegraph/provider-prometheus'
@@ -10,14 +10,14 @@ import { Subscription } from 'rxjs'
 import { addMessageListenersForBackgroundApi } from '../browser-extension/web-extension-api/rpc'
 import { configurationChanges } from '../configuration'
 
-const BUILTIN_PROVIDER_MODULES: Record<string, OpenCodeGraphProvider<any>> = {
+const BUILTIN_PROVIDER_MODULES: Record<string, Provider<any>> = {
     ['https://opencodegraph.org/npm/@opencodegraph/provider-hello-world']: helloWorldProvider,
     ['https://opencodegraph.org/npm/@opencodegraph/provider-links']: linksProvider,
     ['https://opencodegraph.org/npm/@opencodegraph/provider-storybook']: storybookProvider,
     ['https://opencodegraph.org/npm/@opencodegraph/provider-prometheus']: prometheusProvider,
 }
 
-function getBuiltinProvider(uri: string): OpenCodeGraphProvider {
+function getBuiltinProvider(uri: string): Provider {
     const mod = BUILTIN_PROVIDER_MODULES[uri]
     if (!mod) {
         throw new Error(

--- a/client/browser/src/browser-extension/web-extension-api/types.ts
+++ b/client/browser/src/browser-extension/web-extension-api/types.ts
@@ -1,4 +1,4 @@
-import { type Client, type OpenCodeGraphRange } from '@opencodegraph/client'
+import { type Client, type Range } from '@opencodegraph/client'
 
 /**
  * Wrapper type for a string of JSONC (JSON with comments and trailing commas).
@@ -21,7 +21,7 @@ export interface ManagedStorageItems {}
 /**
  * Functions in the background page that can be invoked from content scripts.
  */
-export interface BackgroundApi extends Pick<Client<OpenCodeGraphRange>, 'annotationsChanges'> {}
+export interface BackgroundApi extends Pick<Client<Range>, 'annotationsChanges'> {}
 
 /**
  * Shape of the handler object in the background worker.

--- a/client/browser/src/contentScript/github/codeView.ts
+++ b/client/browser/src/contentScript/github/codeView.ts
@@ -1,4 +1,4 @@
-import { type Annotation, type AnnotationsParams, type OpenCodeGraphItem } from '@opencodegraph/client'
+import { type Annotation, type AnnotationsParams, type Item } from '@opencodegraph/client'
 import { createItemChipList } from '@opencodegraph/ui-standalone'
 import { combineLatest, debounceTime, EMPTY, map, mergeMap, Observable, startWith, tap } from 'rxjs'
 import { toLineRangeStrings } from '../../shared/util/toLineRangeStrings'
@@ -109,7 +109,7 @@ function redraw(annotations: Annotation[]): void {
         }
     }
 
-    function addChipsToCodeRow(line: number, items: OpenCodeGraphItem[]): void {
+    function addChipsToCodeRow(line: number, items: Item[]): void {
         const lineEl = document.querySelector(`.react-file-line[data-line-number="${line + 1}"]`)
         if (lineEl) {
             const chipList = createItemChipList(

--- a/client/codemirror/src/extension.ts
+++ b/client/codemirror/src/extension.ts
@@ -1,6 +1,6 @@
 import { Facet, type Extension } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
-import { type Annotation, type OpenCodeGraphItem } from '@opencodegraph/client'
+import { type Annotation, type Item } from '@opencodegraph/client'
 import { openCodeGraphWidgets } from './itemBlockWidget'
 
 export interface OpenCodeGraphDecorationsConfig {
@@ -12,7 +12,7 @@ export interface OpenCodeGraphDecorationsConfig {
              */
             indent: string | undefined
 
-            items: OpenCodeGraphItem[]
+            items: Item[]
         }
     ) => { destroy?: () => void }
 

--- a/client/codemirror/src/itemBlockWidget.ts
+++ b/client/codemirror/src/itemBlockWidget.ts
@@ -1,6 +1,6 @@
 import { RangeSetBuilder, type EditorState, type Extension } from '@codemirror/state'
 import { Decoration, EditorView, WidgetType, type DecorationSet } from '@codemirror/view'
-import { type Annotation, type OpenCodeGraphItem } from '@opencodegraph/client'
+import { type Annotation, type Item } from '@opencodegraph/client'
 import deepEqual from 'deep-equal'
 import { openCodeGraphDataFacet, type OpenCodeGraphDecorationsConfig } from './extension'
 
@@ -9,7 +9,7 @@ class BlockWidget extends WidgetType {
     private decoration: ReturnType<OpenCodeGraphDecorationsConfig['createDecoration']> | undefined
 
     constructor(
-        private readonly items: OpenCodeGraphItem[],
+        private readonly items: Item[],
         private readonly indent: string | undefined,
         private readonly config: OpenCodeGraphDecorationsConfig
     ) {

--- a/client/monaco-editor/src/index.ts
+++ b/client/monaco-editor/src/index.ts
@@ -1,8 +1,8 @@
-import { type Annotation, type Client, type OpenCodeGraphRange } from '@opencodegraph/client'
+import { type Annotation, type Client, type Range } from '@opencodegraph/client'
 import * as monaco from 'monaco-editor'
 
 /**
- * Like {@link monaco.Range}, but also overlaps with {@link OpenCodeGraphRange}.
+ * Like {@link monaco.Range}, but also overlaps with {@link Range}.
  */
 class MonacoRange extends monaco.Range {
     constructor(startLineNumber: number, startColumn: number, endLineNumber: number, endColumn: number) {
@@ -19,7 +19,7 @@ class MonacoRange extends monaco.Range {
 }
 
 /**
- * Like {@link monaco.Position}, but also overlaps with {@link OpenCodeGraphPosition}.
+ * Like {@link monaco.Position}, but also overlaps with {@link Position}.
  */
 class MonacoPosition extends monaco.Position {
     constructor(position: monaco.Position) {
@@ -35,12 +35,12 @@ class MonacoPosition extends monaco.Position {
 }
 
 /**
- * Convert a {@link OpenCodeGraphRange} to a range that can be used with the Monaco editor
+ * Convert a {@link Range} to a range that can be used with the Monaco editor
  * ({@link monaco.Range}).
  *
  * Use it in {@link import('@opencodegraph/client').createClient}'s `makeRange` environment field.
  */
-export function makeRange(range: OpenCodeGraphRange): MonacoRange {
+export function makeRange(range: Range): MonacoRange {
     return new MonacoRange(range.start.line, range.start.character, range.end.line, range.end.character)
 }
 

--- a/client/vscode/src/controller.ts
+++ b/client/vscode/src/controller.ts
@@ -1,4 +1,4 @@
-import { createClient, type Annotation, type OpenCodeGraphRange } from '@opencodegraph/client'
+import { createClient, type Annotation, type Range } from '@opencodegraph/client'
 import { catchError, combineLatest, from, map, mergeMap, of, tap, type Observable } from 'rxjs'
 import * as vscode from 'vscode'
 import { createApi, type ExtensionApi } from './api'
@@ -142,7 +142,7 @@ function ignoreDoc(doc: vscode.TextDocument): boolean {
     return doc.uri.scheme === 'output' || doc.lineCount > 5000
 }
 
-function makeRange(range: OpenCodeGraphRange): vscode.Range {
+function makeRange(range: Range): vscode.Range {
     return new vscode.Range(range.start.line, range.start.character, range.end.line, range.end.character)
 }
 

--- a/client/vscode/src/dynamicImport.ts
+++ b/client/vscode/src/dynamicImport.ts
@@ -10,11 +10,11 @@
 // When VS Code supports dynamic import()s for extensions, we can remove this.
 
 import { readFile } from 'fs/promises'
-import { type OpenCodeGraphProvider } from '@opencodegraph/client'
+import { type Provider } from '@opencodegraph/client'
 import * as esbuild from 'esbuild-wasm/esm/browser'
 import * as vscode from 'vscode'
 
-function requireFromString(cjsSource: string, filename: string): { default: OpenCodeGraphProvider } {
+function requireFromString(cjsSource: string, filename: string): { default: Provider } {
     const Module: any = module.constructor
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
     const m = new Module()
@@ -27,7 +27,7 @@ function requireFromString(cjsSource: string, filename: string): { default: Open
 export async function dynamicImportFromSource(
     _uri: string,
     esmSource?: string
-): Promise<{ exports: { default: OpenCodeGraphProvider } }> {
+): Promise<{ exports: { default: Provider } }> {
     if (esmSource === undefined) {
         throw new Error('vscode dynamicImport requires esmSource')
     }

--- a/client/vscode/src/ui/fileAnnotationsList.ts
+++ b/client/vscode/src/ui/fileAnnotationsList.ts
@@ -1,4 +1,4 @@
-import { type Annotation, type OpenCodeGraphItem } from '@opencodegraph/client'
+import { type Annotation, type Item } from '@opencodegraph/client'
 import * as vscode from 'vscode'
 import { type Controller } from '../controller'
 
@@ -13,7 +13,7 @@ export function createShowFileAnnotationsList(controller: Controller): vscode.Di
 }
 
 interface QuickPickItem extends vscode.QuickPickItem {
-    item?: OpenCodeGraphItem
+    item?: Item
     firstRange?: vscode.Range
 }
 

--- a/lib/client/src/api.test.ts
+++ b/lib/client/src/api.test.ts
@@ -1,5 +1,5 @@
 import { type AnnotationsParams, type AnnotationsResult } from '@opencodegraph/protocol'
-import { type OpenCodeGraphRange } from '@opencodegraph/schema'
+import { type Range } from '@opencodegraph/schema'
 import { of } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
 import { describe, expect, test } from 'vitest'
@@ -33,7 +33,7 @@ describe('observeAnnotations', () => {
     test('simple', () => {
         testScheduler().run(({ cold, expectObservable }) => {
             expectObservable(
-                observeAnnotations<OpenCodeGraphRange>(
+                observeAnnotations<Range>(
                     cold<ProviderClientWithSettings[]>('a', {
                         a: [{ providerClient: { annotations: () => of(fixtureProviderResult('a')) }, settings: {} }],
                     }),
@@ -47,7 +47,7 @@ describe('observeAnnotations', () => {
     test('no providers', () => {
         testScheduler().run(({ cold, expectObservable }) => {
             expectObservable(
-                observeAnnotations<OpenCodeGraphRange>(
+                observeAnnotations<Range>(
                     cold<ProviderClientWithSettings[]>('a', {
                         a: [],
                     }),
@@ -61,7 +61,7 @@ describe('observeAnnotations', () => {
     test('2 providers', () => {
         testScheduler().run(({ cold, expectObservable }) => {
             expectObservable(
-                observeAnnotations<OpenCodeGraphRange>(
+                observeAnnotations<Range>(
                     cold<ProviderClientWithSettings[]>('a', {
                         a: [
                             { providerClient: { annotations: () => of(fixtureProviderResult('a')) }, settings: {} },
@@ -86,7 +86,7 @@ describe('observeAnnotations', () => {
                 settings: {},
             }
             expectObservable(
-                observeAnnotations<OpenCodeGraphRange>(
+                observeAnnotations<Range>(
                     cold<ProviderClientWithSettings[]>('a', {
                         a: [
                             erroringProvider,
@@ -110,7 +110,7 @@ describe('observeAnnotations', () => {
     test('config changes', () => {
         testScheduler().run(({ cold, expectObservable }) => {
             expectObservable(
-                observeAnnotations<OpenCodeGraphRange>(
+                observeAnnotations<Range>(
                     cold<ProviderClientWithSettings[]>('a-b', {
                         a: [{ providerClient: { annotations: () => of(fixtureProviderResult('a')) }, settings: {} }],
                         b: [

--- a/lib/client/src/api.ts
+++ b/lib/client/src/api.ts
@@ -1,5 +1,5 @@
 import { type AnnotationsParams, type AnnotationsResult, type ProviderSettings } from '@opencodegraph/protocol'
-import { type OpenCodeGraphItem, type OpenCodeGraphRange } from '@opencodegraph/schema'
+import { type Item, type Range } from '@opencodegraph/schema'
 import {
     catchError,
     combineLatest,
@@ -19,8 +19,8 @@ import { type ProviderClient } from './providerClient/createProviderClient'
 /**
  * An OpenCodeGraph annotation.
  */
-export interface Annotation<R extends OpenCodeGraphRange = OpenCodeGraphRange> {
-    item: OpenCodeGraphItem
+export interface Annotation<R extends Range = Range> {
+    item: Item
     range: R
 }
 
@@ -42,7 +42,7 @@ export interface ProviderClientWithSettings {
 /**
  * Observes OpenCodeGraph annotations from the configured providers.
  */
-export function observeAnnotations<R extends OpenCodeGraphRange>(
+export function observeAnnotations<R extends Range>(
     providerClients: Observable<ProviderClientWithSettings[]>,
     params: AnnotationsParams,
     { emitPartial, logger, makeRange }: Pick<ClientEnv<R>, 'logger' | 'makeRange'> & { emitPartial?: boolean }
@@ -65,7 +65,7 @@ export function observeAnnotations<R extends OpenCodeGraphRange>(
         ),
         map(result => mergeData(result)),
         map(result => {
-            const items: Record<string, OpenCodeGraphItem> = {}
+            const items: Record<string, Item> = {}
             for (const item of result.items) {
                 items[item.id] = item
             }

--- a/lib/client/src/client/client.test.ts
+++ b/lib/client/src/client/client.test.ts
@@ -1,5 +1,5 @@
 import { type AnnotationsParams, type AnnotationsResult } from '@opencodegraph/protocol'
-import { type OpenCodeGraphRange } from '@opencodegraph/schema'
+import { type Range } from '@opencodegraph/schema'
 import { firstValueFrom, of } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
 import { describe, expect, test } from 'vitest'
@@ -31,9 +31,9 @@ function fixtureResult(id: string): Annotation {
 }
 
 function createTestClient(
-    env: Partial<ClientEnv<OpenCodeGraphRange>> & Required<Pick<ClientEnv<OpenCodeGraphRange>, 'configuration'>>
-): Client<OpenCodeGraphRange> {
-    return createClient<OpenCodeGraphRange>({
+    env: Partial<ClientEnv<Range>> & Required<Pick<ClientEnv<Range>, 'configuration'>>
+): Client<Range> {
+    return createClient<Range>({
         authInfo: () => of(null),
         makeRange: r => r,
         ...env,

--- a/lib/client/src/client/client.ts
+++ b/lib/client/src/client/client.ts
@@ -1,6 +1,6 @@
 import { type AnnotationsParams, type ProviderSettings } from '@opencodegraph/protocol'
-import { type OpenCodeGraphProvider } from '@opencodegraph/provider'
-import { type OpenCodeGraphRange } from '@opencodegraph/schema'
+import { type Provider } from '@opencodegraph/provider'
+import { type Range } from '@opencodegraph/schema'
 import { LRUCache } from 'lru-cache'
 import {
     catchError,
@@ -27,7 +27,7 @@ import { createProviderClient, type ProviderClient } from '../providerClient/cre
  *
  * @template R The type to use for ranges (such as `vscode.Range` for VS Code extensions).
  */
-export interface ClientEnv<R extends OpenCodeGraphRange> {
+export interface ClientEnv<R extends Range> {
     /**
      * The configuration (set by the user in the client application) that applies to a file,
      * typically the file that is being annotated with OpenCodeGraph information.
@@ -58,23 +58,20 @@ export interface ClientEnv<R extends OpenCodeGraphRange> {
      * @param range A plain range.
      * @returns A "rich" range (such as `vscode.Range`).
      */
-    makeRange: (range: OpenCodeGraphRange) => R
+    makeRange: (range: Range) => R
 
     /**
      * Called (if set) to dynamically import an OpenCodeGraph provider from a URI. This can be used
      * by runtimes that need to pre-bundle providers.
      */
-    dynamicImportFromUri?: (uri: string) => Promise<{ default: OpenCodeGraphProvider }>
+    dynamicImportFromUri?: (uri: string) => Promise<{ default: Provider }>
 
     /**
      * Called (if set) to dynamically import an OpenCodeGraph provider from its ES module source
      * code. This can be used by runtimes that only support `require()` and CommonJS (such as VS
      * Code).
      */
-    dynamicImportFromSource?: (
-        uri: string,
-        esmSource: string
-    ) => Promise<{ exports: { default: OpenCodeGraphProvider } }>
+    dynamicImportFromSource?: (uri: string, esmSource: string) => Promise<{ exports: { default: Provider } }>
 
     /**
      * @internal
@@ -98,7 +95,7 @@ export interface AuthInfo {
  *
  * @template R The type to use for ranges (such as `vscode.Range` for VS Code extensions).
  */
-export interface Client<R extends OpenCodeGraphRange> {
+export interface Client<R extends Range> {
     /**
      * Get the annotations returned by the configured providers for the given file.
      *
@@ -141,7 +138,7 @@ export interface Client<R extends OpenCodeGraphRange> {
  *
  * @template R The type to use for ranges (such as `vscode.Range` for VS Code extensions).
  */
-export function createClient<R extends OpenCodeGraphRange>(env: ClientEnv<R>): Client<R> {
+export function createClient<R extends Range>(env: ClientEnv<R>): Client<R> {
     const subscriptions: Unsubscribable[] = []
 
     const providerCache = createProviderPool()

--- a/lib/client/src/client/testdata/simple.js
+++ b/lib/client/src/client/testdata/simple.js
@@ -1,4 +1,4 @@
-/** @type {import('@opencodegraph/provider').OpenCodeGraphProvider} */
+/** @type {import('@opencodegraph/provider').Provider} */
 export default {
   capabilities: () => ({}),
   annotations: () => ({

--- a/lib/client/src/index.ts
+++ b/lib/client/src/index.ts
@@ -1,5 +1,5 @@
 export type * from '@opencodegraph/protocol'
-export type { OpenCodeGraphProvider } from '@opencodegraph/provider'
+export type { Provider } from '@opencodegraph/provider'
 export type * from '@opencodegraph/schema'
 export { observeAnnotations, type Annotation } from './api'
 export { createClient, type AuthInfo, type Client } from './client/client'

--- a/lib/client/src/providerClient/testdata/annotationsThrow.js
+++ b/lib/client/src/providerClient/testdata/annotationsThrow.js
@@ -1,4 +1,4 @@
-/** @type {import('@opencodegraph/provider').OpenCodeGraphProvider} */
+/** @type {import('@opencodegraph/provider').Provider} */
 export default {
   capabilities() {
     return {}

--- a/lib/client/src/providerClient/testdata/capabilitiesThrow.js
+++ b/lib/client/src/providerClient/testdata/capabilitiesThrow.js
@@ -1,4 +1,4 @@
-/** @type {import('@opencodegraph/provider').OpenCodeGraphProvider} */
+/** @type {import('@opencodegraph/provider').Provider} */
 export default {
   capabilities() {
     throw new Error('capabilitiesThrow')

--- a/lib/client/src/providerClient/testdata/provider.js
+++ b/lib/client/src/providerClient/testdata/provider.js
@@ -1,4 +1,4 @@
-/** @type {import('@opencodegraph/provider').OpenCodeGraphProvider} */
+/** @type {import('@opencodegraph/provider').Provider} */
 export default {
   capabilities: () => ({ selector: [{ path: 'foo' }] }),
   annotations: (_params, settings) => ({

--- a/lib/client/src/providerClient/testdata/transportReuse.js
+++ b/lib/client/src/providerClient/testdata/transportReuse.js
@@ -1,6 +1,6 @@
 global.__test__transportReuseInfo.moduleLoads++
 
-/** @type {import('@opencodegraph/provider').OpenCodeGraphProvider} */
+/** @type {import('@opencodegraph/provider').Provider} */
 export default {
   capabilities() {
     global.__test__transportReuseInfo.capabilitiesCalls++

--- a/lib/client/src/providerClient/transport/module.ts
+++ b/lib/client/src/providerClient/transport/module.ts
@@ -1,4 +1,4 @@
-import { type OpenCodeGraphProvider as Provider } from '@opencodegraph/provider'
+import { type Provider } from '@opencodegraph/provider'
 import type { ProviderTransport, ProviderTransportOptions } from './createTransport'
 
 export function createRemoteModuleFileTransport(

--- a/lib/client/src/providerClient/transport/testdata/commonjsProvider.js
+++ b/lib/client/src/providerClient/transport/testdata/commonjsProvider.js
@@ -1,4 +1,4 @@
-/** @type {import('@opencodegraph/provider').OpenCodeGraphProvider} */
+/** @type {import('@opencodegraph/provider').Provider} */
 module.exports = {
   capabilities: () => ({ selector: [{ path: 'foo' }] }),
 }

--- a/lib/client/src/providerClient/transport/testdata/emoji.js
+++ b/lib/client/src/providerClient/transport/testdata/emoji.js
@@ -1,4 +1,4 @@
-/** @type {import('@opencodegraph/provider').OpenCodeGraphProvider} */
+/** @type {import('@opencodegraph/provider').Provider} */
 export default {
   capabilities: () => ({ selector: [{ path: 'foo' }] }),
 }

--- a/lib/client/src/providerClient/transport/testdata/esmExtProvider.mjs
+++ b/lib/client/src/providerClient/transport/testdata/esmExtProvider.mjs
@@ -1,4 +1,4 @@
-/** @type {import('@opencodegraph/provider').OpenCodeGraphProvider} */
+/** @type {import('@opencodegraph/provider').Provider} */
 export default {
     capabilities: () => ({ selector: [{ path: 'foo' }] }),
 }

--- a/lib/client/src/providerClient/transport/testdata/esmProvider.js
+++ b/lib/client/src/providerClient/transport/testdata/esmProvider.js
@@ -1,4 +1,4 @@
-/** @type {import('@opencodegraph/provider').OpenCodeGraphProvider} */
+/** @type {import('@opencodegraph/provider').Provider} */
 export default {
   capabilities: () => ({ selector: [{ path: 'foo' }] }),
 }

--- a/lib/client/src/providerClient/transport/testdata/esmProvider.ts
+++ b/lib/client/src/providerClient/transport/testdata/esmProvider.ts
@@ -1,6 +1,6 @@
-import { OpenCodeGraphProvider } from '@opencodegraph/provider'
+import { Provider } from '@opencodegraph/provider'
 
-const provider: OpenCodeGraphProvider = {
+const provider: Provider = {
     capabilities: () => ({ selector: [{ path: 'foo' }] }),
     annotations: () => ({ items: [], annotations: [] }),
 }

--- a/lib/protocol/package.json
+++ b/lib/protocol/package.json
@@ -17,7 +17,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "generate": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only ../schema/dev/generateJsonSchemaTypes.ts src/opencodegraph-protocol.schema.json \"import { OpenCodeGraphItem, OpenCodeGraphAnnotation } from '@opencodegraph/schema'\" > src/opencodegraph-protocol.schema.ts && pnpm -w run format \"$PNPM_SCRIPT_SRC_DIR/src/opencodegraph-protocol.schema.ts\"",
+    "generate": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only ../schema/dev/generateJsonSchemaTypes.ts src/opencodegraph-protocol.schema.json \"import { Item, Annotation } from '@opencodegraph/schema'\" > src/opencodegraph-protocol.schema.ts && pnpm -w run format \"$PNPM_SCRIPT_SRC_DIR/src/opencodegraph-protocol.schema.ts\"",
     "build": "pnpm run --silent generate && tsc --build",
     "test": "vitest",
     "prepublishOnly": "tsc --build --clean && pnpm run build"

--- a/lib/protocol/src/opencodegraph-protocol.schema.json
+++ b/lib/protocol/src/opencodegraph-protocol.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "opencodegraph-protocol.schema.json#",
-  "title": "OpenCodeGraphProtocol",
+  "title": "Protocol",
   "description": "OpenCodeGraph client/provider protocol",
   "allowComments": true,
   "oneOf": [
@@ -104,17 +104,17 @@
           "description": "Items that contain information relevant to the file.",
           "type": "array",
           "items": {
-            "$ref": "../../schema/src/opencodegraph.schema.json#/definitions/OpenCodeGraphItem"
+            "$ref": "../../schema/src/opencodegraph.schema.json#/definitions/Item"
           },
-          "tsType": "OpenCodeGraphItem[]"
+          "tsType": "Item[]"
         },
         "annotations": {
           "description": "Annotations that attach items to specific ranges in the file.",
           "type": "array",
           "items": {
-            "$ref": "../../schema/src/opencodegraph.schema.json#/definitions/OpenCodeGraphAnnotation"
+            "$ref": "../../schema/src/opencodegraph.schema.json#/definitions/Annotation"
           },
-          "tsType": "OpenCodeGraphAnnotation[]"
+          "tsType": "Annotation[]"
         }
       }
     }

--- a/lib/protocol/src/opencodegraph-protocol.schema.ts
+++ b/lib/protocol/src/opencodegraph-protocol.schema.ts
@@ -1,9 +1,9 @@
-import { OpenCodeGraphAnnotation, OpenCodeGraphItem } from '@opencodegraph/schema'
+import { Annotation, Item } from '@opencodegraph/schema'
 
 /**
  * OpenCodeGraph client/provider protocol
  */
-export type OpenCodeGraphProtocol =
+export type Protocol =
     | RequestMessage
     | ResponseMessage
     | ResponseError
@@ -73,9 +73,9 @@ export interface AnnotationsResult {
     /**
      * Items that contain information relevant to the file.
      */
-    items: OpenCodeGraphItem[]
+    items: Item[]
     /**
      * Annotations that attach items to specific ranges in the file.
      */
-    annotations: OpenCodeGraphAnnotation[]
+    annotations: Annotation[]
 }

--- a/lib/provider/src/index.ts
+++ b/lib/provider/src/index.ts
@@ -4,7 +4,7 @@
 // eslint-disable-next-line import/extensions
 import matchGlob from 'picomatch/lib/picomatch.js'
 
-export type { Provider as OpenCodeGraphProvider } from './provider'
+export type { Provider as Provider } from './provider'
 export type * from '@opencodegraph/schema'
 export type * from '@opencodegraph/protocol'
 

--- a/lib/schema/src/opencodegraph.schema.json
+++ b/lib/schema/src/opencodegraph.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "opencodegraph.schema.json#",
-  "title": "OpenCodeGraphData",
+  "title": "Data",
   "description": "Metadata about code",
   "allowComments": true,
   "type": "object",
@@ -10,15 +10,15 @@
   "properties": {
     "items": {
       "type": "array",
-      "items": { "$ref": "#/definitions/OpenCodeGraphItem" }
+      "items": { "$ref": "#/definitions/Item" }
     },
     "annotations": {
       "type": "array",
-      "items": { "$ref": "#/definitions/OpenCodeGraphAnnotation" }
+      "items": { "$ref": "#/definitions/Annotation" }
     }
   },
   "definitions": {
-    "OpenCodeGraphItem": {
+    "Item": {
       "type": "object",
       "additionalProperties": false,
       "required": ["id", "title"],
@@ -32,10 +32,10 @@
           "description": "If `preview` is set, show this URL as the preview instead of `url`.",
           "type": "string"
         },
-        "image": { "$ref": "#/definitions/OpenCodeGraphImage" }
+        "image": { "$ref": "#/definitions/ItemImage" }
       }
     },
-    "OpenCodeGraphImage": {
+    "ItemImage": {
       "type": "object",
       "additionalProperties": false,
       "required": ["url"],
@@ -46,14 +46,14 @@
         "alt": { "type": "string" }
       }
     },
-    "OpenCodeGraphAnnotation": {
+    "Annotation": {
       "type": "object",
       "additionalProperties": false,
       "required": ["range", "item"],
       "properties": {
-        "range": { "$ref": "#/definitions/OpenCodeGraphRange" },
+        "range": { "$ref": "#/definitions/Range" },
         "item": {
-          "title": "OpenCodeGraphItemRef",
+          "title": "ItemRef",
           "type": "object",
           "additionalProperties": false,
           "required": ["id"],
@@ -63,16 +63,16 @@
         }
       }
     },
-    "OpenCodeGraphRange": {
+    "Range": {
       "type": "object",
       "additionalProperties": false,
       "required": ["start", "end"],
       "properties": {
-        "start": { "$ref": "#/definitions/OpenCodeGraphPosition" },
-        "end": { "$ref": "#/definitions/OpenCodeGraphPosition" }
+        "start": { "$ref": "#/definitions/Position" },
+        "end": { "$ref": "#/definitions/Position" }
       }
     },
-    "OpenCodeGraphPosition": {
+    "Position": {
       "type": "object",
       "additionalProperties": false,
       "required": ["line", "character"],

--- a/lib/schema/src/opencodegraph.schema.ts
+++ b/lib/schema/src/opencodegraph.schema.ts
@@ -1,11 +1,11 @@
 /**
  * Metadata about code
  */
-export interface OpenCodeGraphData {
-    items: OpenCodeGraphItem[]
-    annotations: OpenCodeGraphAnnotation[]
+export interface Data {
+    items: Item[]
+    annotations: Annotation[]
 }
-export interface OpenCodeGraphItem {
+export interface Item {
     id: string
     title: string
     detail?: string
@@ -21,26 +21,26 @@ export interface OpenCodeGraphItem {
      * If `preview` is set, show this URL as the preview instead of `url`.
      */
     previewUrl?: string
-    image?: OpenCodeGraphImage
+    image?: ItemImage
 }
-export interface OpenCodeGraphImage {
+export interface ItemImage {
     url: string
     width?: number
     height?: number
     alt?: string
 }
-export interface OpenCodeGraphAnnotation {
-    range: OpenCodeGraphRange
-    item: OpenCodeGraphItemRef
+export interface Annotation {
+    range: Range
+    item: ItemRef
 }
-export interface OpenCodeGraphRange {
-    start: OpenCodeGraphPosition
-    end: OpenCodeGraphPosition
+export interface Range {
+    start: Position
+    end: Position
 }
-export interface OpenCodeGraphPosition {
+export interface Position {
     line: number
     character: number
 }
-export interface OpenCodeGraphItemRef {
+export interface ItemRef {
     id: string
 }

--- a/lib/ui-react/src/itemChip/ItemChip.story.tsx
+++ b/lib/ui-react/src/itemChip/ItemChip.story.tsx
@@ -1,8 +1,8 @@
-import type { OpenCodeGraphItem } from '@opencodegraph/schema'
+import type { Item } from '@opencodegraph/schema'
 import { type Meta, type StoryObj } from '@storybook/react'
 import { ItemChip } from './ItemChip'
 
-const FIXTURE_ITEM: OpenCodeGraphItem = {
+const FIXTURE_ITEM: Item = {
     id: 'css-docs',
     title: '📘 Docs: CSS in client/web',
 }

--- a/lib/ui-react/src/itemChip/ItemChip.tsx
+++ b/lib/ui-react/src/itemChip/ItemChip.tsx
@@ -1,4 +1,4 @@
-import { type OpenCodeGraphItem } from '@opencodegraph/schema'
+import { type Item } from '@opencodegraph/schema'
 import classNames from 'classnames'
 import React, { useCallback, useRef, useState } from 'react'
 import styles from './ItemChip.module.css'
@@ -8,7 +8,7 @@ import { Popover } from './Popover'
  * A single OpenCodeGraph item, displayed as a "chip".
  */
 export const ItemChip: React.FunctionComponent<{
-    item: OpenCodeGraphItem
+    item: Item
     className?: string
     popoverClassName?: string
 }> = ({ item, className, popoverClassName }) => {
@@ -43,12 +43,15 @@ export const ItemChip: React.FunctionComponent<{
 }
 
 const ItemTitle: React.FunctionComponent<{
-    title: OpenCodeGraphItem['title']
+    title: Item['title']
 }> = ({ title }) => <h4 className={styles.title}>{title}</h4>
 
-const ItemDetail: React.FunctionComponent<
-    Pick<OpenCodeGraphItem, 'title' | 'detail' | 'image'> & { iframe?: string }
-> = ({ title, detail, image, iframe }) => {
+const ItemDetail: React.FunctionComponent<Pick<Item, 'title' | 'detail' | 'image'> & { iframe?: string }> = ({
+    title,
+    detail,
+    image,
+    iframe,
+}) => {
     // Wait for the iframe to load before displaying it, to reduce visual flicker.
     const [iframeLoaded, setIframeLoaded] = useState(false)
     const onIframeLoad = useCallback<React.ReactEventHandler<HTMLIFrameElement>>(ev => {
@@ -78,7 +81,7 @@ const ItemDetail: React.FunctionComponent<
 }
 
 const ItemImage: React.FunctionComponent<{
-    image: NonNullable<OpenCodeGraphItem['image']>
+    image: NonNullable<Item['image']>
 }> = ({ image }) => (
     <div className={styles.imageContainer}>
         <img src={image.url} alt={image.alt} width={image.width} height={image.height} className={styles.image} />
@@ -89,7 +92,7 @@ const ItemImage: React.FunctionComponent<{
  * A list of OCG items.
  */
 export const ItemChipList: React.FunctionComponent<{
-    items: OpenCodeGraphItem[]
+    items: Item[]
     className?: string
     chipClassName?: string
     popoverClassName?: string

--- a/lib/ui-standalone/src/itemChip/ItemChip.story.ts
+++ b/lib/ui-standalone/src/itemChip/ItemChip.story.ts
@@ -1,4 +1,4 @@
-import { type OpenCodeGraphItem } from '@opencodegraph/schema'
+import { type Item } from '@opencodegraph/schema'
 import type { Meta, StoryObj } from '@storybook/html'
 import { createItemChip } from './ItemChip'
 
@@ -18,7 +18,7 @@ const meta: Meta = {
 
 export default meta
 
-const FIXTURE_ITEM: OpenCodeGraphItem = {
+const FIXTURE_ITEM: Item = {
     id: 'css-docs',
     title: '📘 Docs: CSS in client/web',
 }

--- a/lib/ui-standalone/src/itemChip/ItemChip.ts
+++ b/lib/ui-standalone/src/itemChip/ItemChip.ts
@@ -1,4 +1,4 @@
-import { type OpenCodeGraphItem } from '@opencodegraph/schema'
+import { type Item } from '@opencodegraph/schema'
 import clsx from 'clsx'
 import styles from './ItemChip.module.css'
 import { getPopoverDimensions } from './popover'
@@ -11,7 +11,7 @@ export function createItemChip({
     className,
     popoverClassName,
 }: {
-    item: OpenCodeGraphItem
+    item: Item
     className?: string
     popoverClassName?: string
 }): HTMLElement {
@@ -86,7 +86,7 @@ function createPopoverContent({
     image,
     iframe,
     className,
-}: Pick<OpenCodeGraphItem, 'title' | 'detail' | 'image'> & { iframe?: string; className?: string }): HTMLElement {
+}: Pick<Item, 'title' | 'detail' | 'image'> & { iframe?: string; className?: string }): HTMLElement {
     const el = document.createElement('aside')
     el.className = clsx(styles.popoverContent, className)
 
@@ -150,7 +150,7 @@ export function createItemChipList({
     chipClassName,
     popoverClassName,
 }: {
-    items: OpenCodeGraphItem[]
+    items: Item[]
     className?: string
     chipClassName?: string
     popoverClassName?: string

--- a/provider/hello-world/index.ts
+++ b/provider/hello-world/index.ts
@@ -1,11 +1,11 @@
 import {
+    type Annotation,
     type AnnotationsParams,
     type AnnotationsResult,
     type CapabilitiesParams,
     type CapabilitiesResult,
-    type OpenCodeGraphAnnotation,
-    type OpenCodeGraphItem,
-    type OpenCodeGraphProvider,
+    type Item,
+    type Provider,
     type ProviderSettings,
 } from '@opencodegraph/provider'
 
@@ -13,13 +13,13 @@ import {
  * A demo [OpenCodeGraph](https://opencodegraph.org) provider that annotates every 10th line in every
  * file with "✨ Hello, world!".
  */
-const helloWorld: OpenCodeGraphProvider = {
+const helloWorld: Provider = {
     capabilities(params: CapabilitiesParams, settings: ProviderSettings): CapabilitiesResult {
         return {}
     },
 
     annotations(params: AnnotationsParams, settings: ProviderSettings): AnnotationsResult {
-        const item: OpenCodeGraphItem = {
+        const item: Item = {
             id: 'hello-world',
             title: '✨ Hello, world!',
             detail: 'From OpenCodeGraph',
@@ -27,7 +27,7 @@ const helloWorld: OpenCodeGraphProvider = {
         }
 
         const lines = params.content.split('\n')
-        const annotations: OpenCodeGraphAnnotation[] = []
+        const annotations: Annotation[] = []
         for (const [i, line] of lines.entries()) {
             if (i % 10 !== 0) {
                 continue

--- a/provider/links/index.ts
+++ b/provider/links/index.ts
@@ -4,9 +4,9 @@ import {
     type AnnotationsResult,
     type CapabilitiesParams,
     type CapabilitiesResult,
-    type OpenCodeGraphItem,
-    type OpenCodeGraphProvider,
-    type OpenCodeGraphRange,
+    type Item,
+    type Provider,
+    type Range,
 } from '@opencodegraph/provider'
 
 /** Settings for the `links` OpenCodeGraph provider. */
@@ -65,7 +65,7 @@ interface LinkPattern {
  * These links will be visible in every dev's editor, in code search, on the code host, and in code
  * review (assuming all of those tools have OpenCodeGraph support).
  */
-const links: OpenCodeGraphProvider<Settings> = {
+const links: Provider<Settings> = {
     capabilities(_params: CapabilitiesParams, settings: Settings): CapabilitiesResult {
         return { selector: settings.links?.map(({ path }) => ({ path })) || [] }
     },
@@ -97,7 +97,7 @@ const links: OpenCodeGraphProvider<Settings> = {
 
             const ranges = matchResults(pattern, lines)
             for (const { range, groups } of ranges) {
-                const item: OpenCodeGraphItem = {
+                const item: Item = {
                     id: '',
                     title: interpolate(title, groups),
                     detail: description ? interpolate(description, groups) : undefined,
@@ -128,7 +128,7 @@ const links: OpenCodeGraphProvider<Settings> = {
 export default links
 
 interface MatchResult {
-    range: OpenCodeGraphRange
+    range: Range
     groups?: MatchGroup[]
 }
 

--- a/provider/prometheus/index.ts
+++ b/provider/prometheus/index.ts
@@ -4,10 +4,10 @@ import {
     type AnnotationsResult,
     type CapabilitiesParams,
     type CapabilitiesResult,
-    type OpenCodeGraphItem,
-    type OpenCodeGraphPosition,
-    type OpenCodeGraphProvider,
-    type OpenCodeGraphRange,
+    type Item,
+    type Position,
+    type Provider,
+    type Range,
 } from '@opencodegraph/provider'
 
 /** Settings for the Prometheus OpenCodeGraph provider. */
@@ -56,7 +56,7 @@ interface MetricRegistrationPattern {
  * - TODO(sqs): Hit the Prometheus/Grafana APIs to fetch data (eg `curl -XPOST
  *   'https://prometheus.demo.do.prometheus.io/api/v1/query?query=go_gc_duration_seconds&timeout=200ms'`).
  */
-const prometheus: OpenCodeGraphProvider<Settings> = {
+const prometheus: Provider<Settings> = {
     capabilities(_params: CapabilitiesParams, settings: Settings): CapabilitiesResult {
         return { selector: settings.metricRegistrationPatterns?.map(({ path }) => ({ path })) || [] }
     },
@@ -88,7 +88,7 @@ const prometheus: OpenCodeGraphProvider<Settings> = {
 
             const ranges = matchResults(pattern, params.content, positionCalculator)
             for (const { range, metricName } of ranges) {
-                const item: OpenCodeGraphItem = {
+                const item: Item = {
                     id: '',
                     title: `📟 Prometheus metric: ${metricName}`,
                     url: urlTemplate.replaceAll('$1', metricName),
@@ -114,7 +114,7 @@ const prometheus: OpenCodeGraphProvider<Settings> = {
 export default prometheus
 
 interface MatchResult {
-    range: OpenCodeGraphRange
+    range: Range
     metricName: string
 }
 
@@ -135,7 +135,7 @@ function matchResults(pattern: RegExp, content: string, pos: PositionCalculator)
     return results
 }
 
-type PositionCalculator = (offset: number) => OpenCodeGraphPosition
+type PositionCalculator = (offset: number) => Position
 function createFilePositionCalculator(content: string): PositionCalculator {
     const lines = content.split('\n')
     return (offset: number) => {

--- a/provider/storybook/index.ts
+++ b/provider/storybook/index.ts
@@ -3,10 +3,10 @@ import {
     type AnnotationsResult,
     type CapabilitiesParams,
     type CapabilitiesResult,
-    type OpenCodeGraphImage,
-    type OpenCodeGraphItem,
-    type OpenCodeGraphProvider,
-    type OpenCodeGraphRange,
+    type Item,
+    type ItemImage,
+    type Provider,
+    type Range,
 } from '@opencodegraph/provider'
 
 // Keep in sync with README.md
@@ -31,7 +31,7 @@ export interface Settings {
  * image previews from [Storybook](https://storybook.js.org/), so you can see what your UI
  * components look like.
  */
-const storybook: OpenCodeGraphProvider<Settings> = {
+const storybook: Provider<Settings> = {
     capabilities(_params: CapabilitiesParams, settings: Settings): CapabilitiesResult {
         if (!settings.storybookUrl) {
             return {}
@@ -59,7 +59,7 @@ const storybook: OpenCodeGraphProvider<Settings> = {
                 for (const [i, story] of matches.entries()) {
                     const storyName = getStoryNameAlias(story, params.content)
                     const storyURL = chromaticStoryURL(component, storyName, settings)
-                    const item: OpenCodeGraphItem = {
+                    const item: Item = {
                         id: `${story}:${i}`,
                         title: `🖼️ Storybook: ${component}/${storyName}`,
                         url: storyURL,
@@ -89,7 +89,7 @@ const storybook: OpenCodeGraphProvider<Settings> = {
                 if (storyTitle) {
                     const story = 'Default'
                     const storyURL = chromaticStoryURL(storyTitle, story, settings)
-                    const item: OpenCodeGraphItem = {
+                    const item: Item = {
                         id: `${storyTitle}:${i}`,
                         title: `🖼️ Storybook: ${storyTitle}`,
                         url: storyURL,
@@ -114,9 +114,9 @@ const storybook: OpenCodeGraphProvider<Settings> = {
 
 export default storybook
 
-function firstSubmatchMatches(pattern: RegExp, lines: string[]): { matches: string[]; ranges: OpenCodeGraphRange[] } {
+function firstSubmatchMatches(pattern: RegExp, lines: string[]): { matches: string[]; ranges: Range[] } {
     const matches: string[] = []
-    const ranges: OpenCodeGraphRange[] = []
+    const ranges: Range[] = []
     for (const [i, line] of lines.entries()) {
         const match = line.match(pattern)
         if (match) {
@@ -180,7 +180,7 @@ function chromaticIframeURL(component: string, story: string, settings: Settings
     return url.toString()
 }
 
-async function getImagePreview(storyUrlStr: string): Promise<OpenCodeGraphImage | undefined> {
+async function getImagePreview(storyUrlStr: string): Promise<ItemImage | undefined> {
     const storyUrl = new URL(storyUrlStr)
     if (!storyUrl.hostname.endsWith('.chromatic.com')) {
         return undefined // only oEmbed for Chromatic is supported

--- a/web/content/docs/creating-a-provider.mdx
+++ b/web/content/docs/creating-a-provider.mdx
@@ -10,12 +10,12 @@ An OpenCodeGraph provider is just an HTTP server that implements the [provider A
 For convenience, you can also just bundle and publish a `.js` file that implements the simple `@opencodegraph/provider` TypeScript API (as a default export):
 
 ```typescript
-import type { AnnotationsParams, AnnotationsResult, CapabilitiesParams, CapabilitiesResult, OpenCodeGraphProvider } from '@opencodegraph/provider'
+import type { AnnotationsParams, AnnotationsResult, CapabilitiesParams, CapabilitiesResult, Provider } from '@opencodegraph/provider'
 
 export default {
   capabilities(params: CapabilitiesParams): Promise<CapabilitiesResult> { /* ... */ }
   annotations(params: AnnotationsParams): Promise<AnnotationsResult> { /* ... */ }
-} satisfies OpenCodeGraphProvider
+} satisfies Provider
 ```
 
 Then use the URL (`file://` or `https://`) to that `.js` file. This way, you don't need to deploy a public HTTP server for the provider. See the [playground](/playground) for examples.

--- a/web/content/docs/protocol.mdx
+++ b/web/content/docs/protocol.mdx
@@ -100,13 +100,13 @@ interface AnnotationsParams {
 ```typescript
 interface AnnotationsResult {
   /** Items that contain information relevant to the file. */
-  items: OpenCodeGraphItem[]
+  items: Item[]
 
   /** Annotations that attach items to specific ranges in the file. */
-  annotations: OpenCodeGraphAnnotation[]
+  annotations: Annotation[]
 }
 
-interface OpenCodeGraphItem {
+interface Item {
   id: string
 
   title: string
@@ -119,8 +119,8 @@ interface OpenCodeGraphItem {
   // Some fields omitted.
 }
 
-interface OpenCodeGraphAnnotation {
-  /** The item (referenced by its `OpenCodeGraph.id`). */
+interface Annotation {
+  /** The item (referenced by its `Item.id`). */
   item: { id: string }
 
   /** The range in the file that the item is relevant to. */


### PR DESCRIPTION
It was not needed and added noise to the code.

```
fastmod -e tsx,ts,md,mdx,json,mjs,js OpenCodeGraphRange Range
fastmod -e tsx,ts,md,mdx,json,mjs,js OpenCodeGraphPosition Position
fastmod -e tsx,ts,md,mdx,json,mjs,js OpenCodeGraphProvider Provider
fastmod -e tsx,ts,md,mdx,json,mjs,js OpenCodeGraphItem Item
```