### PR TITLE
remove preview and previewUrl

### DIFF
--- a/lib/schema/src/opencodegraph.schema.json
+++ b/lib/schema/src/opencodegraph.schema.json
@@ -27,11 +27,6 @@
         "title": { "type": "string" },
         "detail": { "type": "string" },
         "url": { "description": "An external URL with more information.", "type": "string", "format": "uri" },
-        "preview": { "description": "Show a preview of the link.", "type": "boolean" },
-        "previewUrl": {
-          "description": "If `preview` is set, show this URL as the preview instead of `url`.",
-          "type": "string"
-        },
         "image": { "$ref": "#/definitions/ItemImage" }
       }
     },

--- a/lib/schema/src/opencodegraph.schema.ts
+++ b/lib/schema/src/opencodegraph.schema.ts
@@ -13,14 +13,6 @@ export interface Item {
      * An external URL with more information.
      */
     url?: string
-    /**
-     * Show a preview of the link.
-     */
-    preview?: boolean
-    /**
-     * If `preview` is set, show this URL as the preview instead of `url`.
-     */
-    previewUrl?: string
     image?: ItemImage
 }
 export interface ItemImage {

--- a/lib/ui-react/src/itemChip/ItemChip.module.css
+++ b/lib/ui-react/src/itemChip/ItemChip.module.css
@@ -49,34 +49,6 @@
     object-fit: contain;
 }
 
-:root {
-    --iframe-width: 350px;
-    --iframe-height: 210px;
-    --iframe-scale: 0.6;
-}
-
-.iframe-container {
-    width: var(--iframe-width);
-    height: var(--iframe-height);
-    overflow: hidden;
-    position: relative;
-}
-
-.iframe {
-    border: 0;
-    width: calc(var(--iframe-width) / var(--iframe-scale));
-    height: calc(var(--iframe-height) / var(--iframe-scale));
-    transform: scale(var(--iframe-scale));
-    transform-origin: 0 0;
-    position: absolute;
-    opacity: 0;
-}
-
-.iframe--loaded {
-    opacity: 1;
-    transition: opacity 0.1s ease-in-out;
-}
-
 .stretched-link::after {
     position: absolute;
     top: 0;

--- a/lib/ui-react/src/itemChip/ItemChip.story.tsx
+++ b/lib/ui-react/src/itemChip/ItemChip.story.tsx
@@ -49,13 +49,3 @@ export const Image: Story = {
         },
     },
 }
-
-export const Iframe: Story = {
-    args: {
-        item: {
-            ...FIXTURE_ITEM,
-            url: 'https://example.com',
-            preview: true,
-        },
-    },
-}

--- a/lib/ui-react/src/itemChip/ItemChip.tsx
+++ b/lib/ui-react/src/itemChip/ItemChip.tsx
@@ -12,7 +12,7 @@ export const ItemChip: React.FunctionComponent<{
     className?: string
     popoverClassName?: string
 }> = ({ item, className, popoverClassName }) => {
-    const hasDetail = Boolean(item.detail || item.image || ((item.url || item.previewUrl) && item.preview))
+    const hasDetail = Boolean(item.detail || item.image)
 
     const [popoverVisible, setPopoverVisible] = useState(false)
     const showPopover = useCallback((): void => setPopoverVisible(true), [])
@@ -29,12 +29,7 @@ export const ItemChip: React.FunctionComponent<{
             {hasDetail && anchorRef.current && (
                 <Popover anchor={anchorRef.current} visible={popoverVisible}>
                     <aside className={classNames(styles.popoverContent, popoverClassName)}>
-                        <ItemDetail
-                            title={item.title}
-                            detail={item.detail}
-                            image={item.image}
-                            iframe={item.preview ? item.previewUrl ?? item.url : undefined}
-                        />
+                        <ItemDetail title={item.title} detail={item.detail} image={item.image} />
                     </aside>
                 </Popover>
             )}
@@ -46,39 +41,12 @@ const ItemTitle: React.FunctionComponent<{
     title: Item['title']
 }> = ({ title }) => <h4 className={styles.title}>{title}</h4>
 
-const ItemDetail: React.FunctionComponent<Pick<Item, 'title' | 'detail' | 'image'> & { iframe?: string }> = ({
-    title,
-    detail,
-    image,
-    iframe,
-}) => {
-    // Wait for the iframe to load before displaying it, to reduce visual flicker.
-    const [iframeLoaded, setIframeLoaded] = useState(false)
-    const onIframeLoad = useCallback<React.ReactEventHandler<HTMLIFrameElement>>(ev => {
-        // Calling setTimeout reduces the visual flicker.
-        setTimeout(() => setIframeLoaded(true))
-    }, [])
-    return (
-        <>
-            {detail && <p className={styles.detail}>{detail}</p>}
-            {image && <ItemImage image={image} />}
-            {iframe && !image && (
-                <div className={styles.iframeContainer}>
-                    <iframe
-                        title={title}
-                        className={classNames(styles.iframe, iframeLoaded ? styles.iframeLoaded : null)}
-                        src={iframe}
-                        frameBorder={0}
-                        scrolling="no"
-                        tabIndex={-1}
-                        sandbox="allow-scripts allow-same-origin"
-                        onLoad={onIframeLoad}
-                    />
-                </div>
-            )}
-        </>
-    )
-}
+const ItemDetail: React.FunctionComponent<Pick<Item, 'title' | 'detail' | 'image'>> = ({ detail, image }) => (
+    <>
+        {detail && <p className={styles.detail}>{detail}</p>}
+        {image && <ItemImage image={image} />}
+    </>
+)
 
 const ItemImage: React.FunctionComponent<{
     image: NonNullable<Item['image']>

--- a/lib/ui-standalone/src/itemChip/ItemChip.module.css
+++ b/lib/ui-standalone/src/itemChip/ItemChip.module.css
@@ -61,34 +61,6 @@
     object-fit: contain;
 }
 
-:root {
-    --iframe-width: 350px;
-    --iframe-height: 210px;
-    --iframe-scale: 0.6;
-}
-
-.iframe-container {
-    width: var(--iframe-width);
-    height: var(--iframe-height);
-    overflow: hidden;
-    position: relative;
-}
-
-.iframe {
-    border: 0;
-    width: calc(var(--iframe-width) / var(--iframe-scale));
-    height: calc(var(--iframe-height) / var(--iframe-scale));
-    transform: scale(var(--iframe-scale));
-    transform-origin: 0 0;
-    position: absolute;
-    opacity: 0;
-}
-
-.iframe--loaded {
-    opacity: 1;
-    transition: opacity 0.1s ease-in-out;
-}
-
 .stretched-link::after {
     position: absolute;
     top: 0;

--- a/lib/ui-standalone/src/itemChip/ItemChip.story.ts
+++ b/lib/ui-standalone/src/itemChip/ItemChip.story.ts
@@ -46,7 +46,3 @@ export const Image: StoryObj = {
             },
         }),
 }
-
-export const Iframe: StoryObj = {
-    render: () => createItemChip({ item: { ...FIXTURE_ITEM, url: 'https://example.com', preview: true } }),
-}

--- a/lib/ui-standalone/src/itemChip/ItemChip.ts
+++ b/lib/ui-standalone/src/itemChip/ItemChip.ts
@@ -15,7 +15,7 @@ export function createItemChip({
     className?: string
     popoverClassName?: string
 }): HTMLElement {
-    const hasDetail = Boolean(item.detail || item.image || ((item.url || item.previewUrl) && item.preview))
+    const hasDetail = Boolean(item.detail || item.image)
 
     const el = document.createElement('aside')
     el.className = clsx(styles.item, hasDetail ? styles.itemHasDetail : null, className)
@@ -48,7 +48,6 @@ export function createItemChip({
         popoverEl.append(
             createPopoverContent({
                 ...item,
-                iframe: item.preview ? item.previewUrl ?? item.url : undefined,
                 className: popoverClassName,
             })
         )
@@ -81,12 +80,10 @@ export function createItemChip({
 }
 
 function createPopoverContent({
-    title,
     detail,
     image,
-    iframe,
     className,
-}: Pick<Item, 'title' | 'detail' | 'image'> & { iframe?: string; className?: string }): HTMLElement {
+}: Pick<Item, 'detail' | 'image'> & { className?: string }): HTMLElement {
     const el = document.createElement('aside')
     el.className = clsx(styles.popoverContent, className)
 
@@ -112,30 +109,6 @@ function createPopoverContent({
 
         imageContainerEl.append(imageEl)
         el.append(imageContainerEl)
-    }
-
-    if (iframe) {
-        const iframeContainerEl = document.createElement('div')
-        iframeContainerEl.className = styles.iframeContainer
-
-        const iframeEl = document.createElement('iframe')
-        iframeEl.className = styles.iframe
-        iframeEl.src = iframe
-        iframeEl.title = title
-        iframeEl.frameBorder = '0'
-        iframeEl.scrolling = 'no'
-        iframeEl.tabIndex = -1
-        iframeEl.sandbox.add('allow-scripts', 'allow-same-origin')
-
-        // Wait for the iframe to load before displaying it, to reduce visual flicker.
-        const onIframeLoad = (): void => {
-            iframeEl.classList.add(styles.iframeLoaded)
-            iframeEl.removeEventListener('load', onIframeLoad)
-        }
-        iframeEl.addEventListener('load', onIframeLoad)
-
-        iframeContainerEl.append(iframeEl)
-        el.append(iframeContainerEl)
     }
 
     return el

--- a/provider/links/index.test.ts
+++ b/provider/links/index.test.ts
@@ -38,7 +38,6 @@ describe('links', () => {
                     id: 'https://example.com/foo:Foo:',
                     title: '📘 Docs: Foo',
                     url: 'https://example.com/foo',
-                    preview: true,
                 },
             ],
             annotations: [
@@ -81,7 +80,6 @@ describe('links', () => {
                     title: 'Print foo $3 b/a+r',
                     detail: 'b/a+r',
                     url: 'https://example.com/search?q=b%2Fa%2Br',
-                    preview: undefined,
                 },
             ],
             annotations: [

--- a/provider/links/index.ts
+++ b/provider/links/index.ts
@@ -90,7 +90,7 @@ const links: Provider<Settings> = {
 
         const lines = params.content.split(/\r?\n/)
 
-        for (const { title, url, description, preview, type, matchPath, pattern } of compiledPatterns || []) {
+        for (const { title, url, description, type, matchPath, pattern } of compiledPatterns || []) {
             if (!matchPath(new URL(params.file).pathname)) {
                 continue
             }
@@ -102,7 +102,6 @@ const links: Provider<Settings> = {
                     title: interpolate(title, groups),
                     detail: description ? interpolate(description, groups) : undefined,
                     url: interpolate(url, groups),
-                    preview,
                 }
                 item.id = `${item.url}:${item.title}:${item.detail || ''}`
 

--- a/provider/prometheus/index.test.ts
+++ b/provider/prometheus/index.test.ts
@@ -40,7 +40,6 @@ var histogram = promauto.NewHistogram(prometheus.HistogramOpts{
                     id: 'random_numbers',
                     title: '📟 Prometheus metric: random_numbers',
                     url: 'https://example.com/?q=random_numbers',
-                    preview: true,
                 },
             ],
             annotations: [

--- a/provider/prometheus/index.ts
+++ b/provider/prometheus/index.ts
@@ -92,7 +92,6 @@ const prometheus: Provider<Settings> = {
                     id: '',
                     title: `📟 Prometheus metric: ${metricName}`,
                     url: urlTemplate.replaceAll('$1', metricName),
-                    preview: true,
                 }
                 item.id = metricName
 

--- a/provider/storybook/index.test.ts
+++ b/provider/storybook/index.test.ts
@@ -57,9 +57,6 @@ export const Bar: Story = {}
                         id: 'Foo:0',
                         title: '🖼️ Storybook: a/b/Foo',
                         url: 'https://main--abc123.chromatic.com/?path=%2Fstory%2Fa-b--foo',
-                        preview: true,
-                        previewUrl:
-                            'https://main--abc123.chromatic.com/iframe.html?id=a-b--foo&singleStory=true&controls=false&embed=true&viewMode=story',
                         image: {
                             url: 'https://example.com/thumbnail.png',
                             alt: 'chromatic-oembed-image',
@@ -71,9 +68,6 @@ export const Bar: Story = {}
                         id: 'Bar:1',
                         title: '🖼️ Storybook: a/b/Bar',
                         url: 'https://main--abc123.chromatic.com/?path=%2Fstory%2Fa-b--bar',
-                        preview: true,
-                        previewUrl:
-                            'https://main--abc123.chromatic.com/iframe.html?id=a-b--bar&singleStory=true&controls=false&embed=true&viewMode=story',
                     },
                 ],
                 annotations: [

--- a/provider/storybook/index.ts
+++ b/provider/storybook/index.ts
@@ -63,8 +63,6 @@ const storybook: Provider<Settings> = {
                         id: `${story}:${i}`,
                         title: `🖼️ Storybook: ${component}/${storyName}`,
                         url: storyURL,
-                        preview: true,
-                        previewUrl: chromaticIframeURL(component, storyName, settings),
                     }
 
                     item.image = await getImagePreview(storyURL)
@@ -93,8 +91,6 @@ const storybook: Provider<Settings> = {
                         id: `${storyTitle}:${i}`,
                         title: `🖼️ Storybook: ${storyTitle}`,
                         url: storyURL,
-                        preview: true,
-                        previewUrl: chromaticIframeURL(storyTitle, story, settings),
                     }
 
                     item.image = await getImagePreview(storyURL)
@@ -167,16 +163,6 @@ function rootStorybookURL(settings: Settings): URL {
 function chromaticStoryURL(component: string, story: string, settings: Settings): string {
     const url = rootStorybookURL(settings)
     url.searchParams.set('path', `/story/${chromaticStorySlug(component, story)}`)
-    return url.toString()
-}
-
-function chromaticIframeURL(component: string, story: string, settings: Settings): string {
-    const url = new URL('/iframe.html', rootStorybookURL(settings))
-    url.searchParams.set('id', chromaticStorySlug(component, story))
-    url.searchParams.set('singleStory', 'true')
-    url.searchParams.set('controls', 'false')
-    url.searchParams.set('embed', 'true')
-    url.searchParams.set('viewMode', 'story')
     return url.toString()
 }
 

--- a/web/pages/playground/Preload.tsx
+++ b/web/pages/playground/Preload.tsx
@@ -4,15 +4,13 @@ import { PRELOAD_RESOURCES } from './data.ts'
 /**
  * Preloads the resources used in the playground so that the hovers are faster.
  */
-export const Preload: FunctionComponent<{ preloadIframes?: boolean }> = ({ preloadIframes = false }) => (
+export const Preload: FunctionComponent = () => (
     <div className="hidden">
         {PRELOAD_RESOURCES.map(({ url, as }) =>
             as === 'image' ? (
                 <img key={url} src={url} alt="" />
             ) : as === 'script' ? (
                 <script key={url} src={url.replace('https+js', 'https')} type="module" async={true} />
-            ) : preloadIframes ? (
-                <iframe key={url} title={url} src={url} sandbox="allow-scripts allow-same-origin" />
             ) : null
         )}
     </div>


### PR DESCRIPTION
It was a neat demo to show an iframe when you hover a chip, but in reality it is hard to implement and make actually good:

- VS Code does not support iframes
- The user's browser may not load the iframe with their authentication, so it would only work for public resources
- Iframes introduce UI jitter because they are slow to load
- The content in iframes is hard to read

This only worked on the web (in the OpenCodeGraph integrations for [CodeMirror](https://opencodegraph.org/docs/clients/codemirror), [Sourcegraph](https://opencodegraph.org/docs/clients/sourcegraph), and [GitHub](https://opencodegraph.org/docs/clients/github)). This means that, for example, that the following chip will no longer show the iframe hover:

<img width="400" alt="image" src="https://github.com/sourcegraph/opencodegraph/assets/1976/54f12f54-c428-4968-9e45-0e7fdfd17735">

But images still work. For example, this chip will still show the image hover:

<img width="400" alt="image" src="https://github.com/sourcegraph/opencodegraph/assets/1976/e885560e-381f-469d-8c1e-1b40dc58a6cd">

Providers can also display text in the hover, which they could fetch from the destination URL.