### PR TITLE
simplify AnnotationsResult

### DIFF
--- a/client/monaco-editor/src/index.ts
+++ b/client/monaco-editor/src/index.ts
@@ -73,7 +73,7 @@ export function createExtension(client: Client<MonacoRange>): MonacoExtension {
                     const anns = await client.annotations({ file: model.uri.toString(), content: model.getValue() })
 
                     return {
-                        lenses: anns.map((ann, i) => toCodeLens(ann, i)),
+                        lenses: anns.map(toCodeLens),
                         dispose: () => {},
                     }
                 },
@@ -90,9 +90,8 @@ export function createExtension(client: Client<MonacoRange>): MonacoExtension {
     }
 }
 
-function toCodeLens(ann: Annotation<MonacoRange>, i: number): monaco.languages.CodeLens {
+function toCodeLens(ann: Annotation<MonacoRange>): monaco.languages.CodeLens {
     return {
-        id: `${ann.item.id}:${i}`,
         command: {
             title: ann.item.title,
             tooltip: ann.item.detail,

--- a/client/vscode/src/ui/fileAnnotationsList.ts
+++ b/client/vscode/src/ui/fileAnnotationsList.ts
@@ -97,12 +97,9 @@ async function showQuickPick(controller: Controller): Promise<void> {
 }
 
 function toQuickPickItems(anns: Annotation<vscode.Range>[]): QuickPickItem[] {
-    const items = new Map<string, QuickPickItem & Required<Pick<QuickPickItem, 'item' | 'firstRange'>>>()
+    const items: (QuickPickItem & Required<Pick<QuickPickItem, 'item' | 'firstRange'>>)[] = []
     for (const ann of anns) {
-        if (items.has(ann.item.id)) {
-            continue
-        }
-        items.set(ann.item.id, {
+        items.push({
             label: ann.item.title,
             detail: ann.item.detail,
             buttons: ann.item.url
@@ -112,5 +109,5 @@ function toQuickPickItems(anns: Annotation<vscode.Range>[]): QuickPickItem[] {
             firstRange: ann.range,
         })
     }
-    return [...items.values()].sort((a, b) => a.firstRange.start.compareTo(b.firstRange.start))
+    return items.sort((a, b) => a.firstRange.start.compareTo(b.firstRange.start))
 }

--- a/lib/client/src/api.test.ts
+++ b/lib/client/src/api.test.ts
@@ -10,16 +10,18 @@ const FIXTURE_PARAMS: AnnotationsParams = {
     content: 'A',
 }
 
-function fixtureProviderResult(id: string): AnnotationsResult {
-    return {
-        items: [{ id, title: id.toUpperCase() }],
-        annotations: [{ item: { id }, range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } } }],
-    }
+function fixtureProviderResult(label: string): AnnotationsResult {
+    return [
+        {
+            item: { title: label.toUpperCase() },
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+        },
+    ]
 }
 
-function fixtureResult(id: string): Annotation {
+function fixtureResult(label: string): Annotation {
     return {
-        item: { id, title: id.toUpperCase() },
+        item: { title: label.toUpperCase() },
         range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
     }
 }

--- a/lib/client/src/client/client.test.ts
+++ b/lib/client/src/client/client.test.ts
@@ -16,16 +16,18 @@ const FIXTURE_PARAMS: AnnotationsParams = {
     content: 'A',
 }
 
-function fixtureProviderResult(id: string): AnnotationsResult {
-    return {
-        items: [{ id, title: id.toUpperCase() }],
-        annotations: [{ item: { id }, range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } } }],
-    }
+function fixtureProviderResult(label: string): AnnotationsResult {
+    return [
+        {
+            item: { title: label.toUpperCase() },
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+        },
+    ]
 }
 
-function fixtureResult(id: string): Annotation {
+function fixtureResult(label: string): Annotation {
     return {
-        item: { id, title: id.toUpperCase() },
+        item: { title: label.toUpperCase() },
         range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
     }
 }
@@ -51,10 +53,10 @@ describe('Client', () => {
                     Promise.resolve({ enable: true, providers: { [testdataFileUri('simple.js')]: {} } }),
             })
 
-            const anns = simplifyItemIds(await client.annotations(FIXTURE_PARAMS))
+            const anns = await client.annotations(FIXTURE_PARAMS)
             expect(anns).toStrictEqual<typeof anns>([
                 {
-                    item: { id: 'a', title: 'A' },
+                    item: { title: 'A' },
                     range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
                 },
             ])
@@ -87,10 +89,3 @@ describe('Client', () => {
         })
     })
 })
-
-/**
- * Item IDs include the absolute file path to the provider, which is not portable.
- */
-function simplifyItemIds(anns: Annotation[]): Annotation[] {
-    return anns.map(ann => ({ ...ann, item: { ...ann.item, id: ann.item.id.slice(ann.item.id.lastIndexOf('/') + 1) } }))
-}

--- a/lib/client/src/client/testdata/simple.js
+++ b/lib/client/src/client/testdata/simple.js
@@ -1,13 +1,10 @@
 /** @type {import('@opencodegraph/provider').Provider} */
 export default {
   capabilities: () => ({}),
-  annotations: () => ({
-    items: [{ id: 'a', title: 'A' }],
-    annotations: [
-      {
-        item: { id: 'a' },
-        range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
-      },
-    ],
-  }),
+  annotations: () => [
+    {
+      item: { title: 'A' },
+      range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+    },
+  ],
 }

--- a/lib/client/src/providerClient/createProviderClient.test.ts
+++ b/lib/client/src/providerClient/createProviderClient.test.ts
@@ -14,16 +14,13 @@ describe('createProviderClient', () => {
 
         // File URI that satisfies the provider's selector.
         expect(
-            simplifyItemIds(await pc.annotations({ file: 'file:///foo', content: 'A\nB\nC\nD' }, settings))
-        ).toStrictEqual<AnnotationsResult | null>({
-            items: [{ id: 'a', title: 'ABC' }],
-            annotations: [
-                {
-                    item: { id: 'a' },
-                    range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
-                },
-            ],
-        })
+            await pc.annotations({ file: 'file:///foo', content: 'A\nB\nC\nD' }, settings)
+        ).toStrictEqual<AnnotationsResult | null>([
+            {
+                item: { title: 'ABC' },
+                range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+            },
+        ])
 
         // File URI that does NOT satisfy the provider's selector.
         expect(
@@ -96,19 +93,3 @@ describe('createProviderClient', () => {
         expect(info.annotationsCalls).toBe(3)
     })
 })
-
-/**
- * Item IDs include the absolute file path to the provider, which is not portable.
- */
-function simplifyItemIds(result: AnnotationsResult | null): AnnotationsResult | null {
-    if (result === null) {
-        return null
-    }
-    return {
-        items: result.items.map(item => ({ ...item, id: item.id.slice(item.id.lastIndexOf('/') + 1) })),
-        annotations: result.annotations.map(ann => ({
-            ...ann,
-            item: { id: ann.item.id.slice(ann.item.id.lastIndexOf('/') + 1) },
-        })),
-    }
-}

--- a/lib/client/src/providerClient/createProviderClient.ts
+++ b/lib/client/src/providerClient/createProviderClient.ts
@@ -56,25 +56,11 @@ export function createProviderClient(
                 return null
             }
             try {
-                const result = await transport.annotations(params, settings)
-                return addProviderIdPrefix(providerUri, result)
+                return await transport.annotations(params, settings)
             } catch (error) {
                 logger?.(`failed to get annotations: ${error}`)
                 return Promise.reject(error)
             }
         },
-    }
-}
-
-/**
- * Namespace item IDs so that they do not collide across providers.
- */
-function addProviderIdPrefix(providerUri: string, result: AnnotationsResult): AnnotationsResult {
-    return {
-        items: result.items.map(item => ({ ...item, id: `${providerUri}/${item.id}` })),
-        annotations: result.annotations.map(annotation => ({
-            ...annotation,
-            item: { id: `${providerUri}/${annotation.item.id}` },
-        })),
     }
 }

--- a/lib/client/src/providerClient/testdata/provider.js
+++ b/lib/client/src/providerClient/testdata/provider.js
@@ -1,13 +1,10 @@
 /** @type {import('@opencodegraph/provider').Provider} */
 export default {
   capabilities: () => ({ selector: [{ path: 'foo' }] }),
-  annotations: (_params, settings) => ({
-    items: [{ id: 'a', title: settings.myItemTitle }],
-    annotations: [
-      {
-        item: { id: 'a' },
-        range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
-      },
-    ],
-  }),
+  annotations: (_params, settings) => [
+    {
+      item: { title: settings.myItemTitle },
+      range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
+    },
+  ],
 }

--- a/lib/client/src/providerClient/transport/createTransport.test.ts
+++ b/lib/client/src/providerClient/transport/createTransport.test.ts
@@ -45,7 +45,7 @@ describe('createTransport', () => {
                     return Promise.resolve({
                         default: {
                             capabilities: () => ({ selector: [{ path: 'asdf' }] }),
-                            annotations: () => ({ annotations: [], items: [] }),
+                            annotations: () => [],
                         },
                     })
                 },
@@ -60,7 +60,7 @@ describe('createTransport', () => {
                     return Promise.resolve({
                         default: {
                             capabilities: () => ({ selector: [{ path: 'asdf' }] }),
-                            annotations: () => ({ annotations: [], items: [] }),
+                            annotations: () => [],
                         },
                     })
                 },
@@ -80,7 +80,7 @@ describe('createTransport', () => {
                         exports: {
                             default: {
                                 capabilities: () => ({ selector: [{ path: 'asdf' }] }),
-                                annotations: () => ({ annotations: [], items: [] }),
+                                annotations: () => [],
                             },
                         },
                     })

--- a/lib/client/src/providerClient/transport/testdata/esmProvider.ts
+++ b/lib/client/src/providerClient/transport/testdata/esmProvider.ts
@@ -2,7 +2,7 @@ import { Provider } from '@opencodegraph/provider'
 
 const provider: Provider = {
     capabilities: () => ({ selector: [{ path: 'foo' }] }),
-    annotations: () => ({ items: [], annotations: [] }),
+    annotations: () => [],
 }
 
 export default provider

--- a/lib/protocol/src/opencodegraph-protocol.schema.json
+++ b/lib/protocol/src/opencodegraph-protocol.schema.json
@@ -96,27 +96,11 @@
       }
     },
     "AnnotationsResult": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["items", "annotations"],
-      "properties": {
-        "items": {
-          "description": "Items that contain information relevant to the file.",
-          "type": "array",
-          "items": {
-            "$ref": "../../schema/src/opencodegraph.schema.json#/definitions/Item"
-          },
-          "tsType": "Item[]"
-        },
-        "annotations": {
-          "description": "Annotations that attach items to specific ranges in the file.",
-          "type": "array",
-          "items": {
-            "$ref": "../../schema/src/opencodegraph.schema.json#/definitions/Annotation"
-          },
-          "tsType": "Annotation[]"
-        }
-      }
+      "type": "array",
+      "items": {
+        "$ref": "../../schema/src/opencodegraph.schema.json#/definitions/Annotation"
+      },
+      "tsType": "Annotation[]"
     }
   }
 }

--- a/lib/protocol/src/opencodegraph-protocol.schema.ts
+++ b/lib/protocol/src/opencodegraph-protocol.schema.ts
@@ -1,4 +1,4 @@
-import { Annotation, Item } from '@opencodegraph/schema'
+import { Annotation } from '@opencodegraph/schema'
 
 /**
  * OpenCodeGraph client/provider protocol
@@ -12,6 +12,7 @@ export type Protocol =
     | CapabilitiesResult
     | AnnotationsParams
     | AnnotationsResult
+export type AnnotationsResult = Annotation[]
 
 export interface RequestMessage {
     method: string
@@ -68,14 +69,4 @@ export interface AnnotationsParams {
      * The file's content.
      */
     content: string
-}
-export interface AnnotationsResult {
-    /**
-     * Items that contain information relevant to the file.
-     */
-    items: Item[]
-    /**
-     * Annotations that attach items to specific ranges in the file.
-     */
-    annotations: Annotation[]
 }

--- a/lib/schema/src/opencodegraph.schema.json
+++ b/lib/schema/src/opencodegraph.schema.json
@@ -6,24 +6,28 @@
   "allowComments": true,
   "type": "object",
   "additionalProperties": false,
-  "required": ["items", "annotations"],
   "properties": {
-    "items": {
-      "type": "array",
-      "items": { "$ref": "#/definitions/Item" }
-    },
     "annotations": {
       "type": "array",
       "items": { "$ref": "#/definitions/Annotation" }
     }
   },
   "definitions": {
+    "Annotation": {
+      "description": "An annotation describes information relevant to a specific range in a file.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["item", "range"],
+      "properties": {
+        "item": { "$ref": "#/definitions/Item" },
+        "range": { "$ref": "#/definitions/Range" }
+      }
+    },
     "Item": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "title"],
+      "required": ["title"],
       "properties": {
-        "id": { "type": "string" },
         "title": { "type": "string" },
         "detail": { "type": "string" },
         "url": { "description": "An external URL with more information.", "type": "string", "format": "uri" },
@@ -39,23 +43,6 @@
         "width": { "type": "number" },
         "height": { "type": "number" },
         "alt": { "type": "string" }
-      }
-    },
-    "Annotation": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["range", "item"],
-      "properties": {
-        "range": { "$ref": "#/definitions/Range" },
-        "item": {
-          "title": "ItemRef",
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["id"],
-          "properties": {
-            "id": { "type": "string" }
-          }
-        }
       }
     },
     "Range": {

--- a/lib/schema/src/opencodegraph.schema.ts
+++ b/lib/schema/src/opencodegraph.schema.ts
@@ -2,11 +2,16 @@
  * Metadata about code
  */
 export interface Data {
-    items: Item[]
-    annotations: Annotation[]
+    annotations?: Annotation[]
+}
+/**
+ * An annotation describes information relevant to a specific range in a file.
+ */
+export interface Annotation {
+    item: Item
+    range: Range
 }
 export interface Item {
-    id: string
     title: string
     detail?: string
     /**
@@ -21,10 +26,6 @@ export interface ItemImage {
     height?: number
     alt?: string
 }
-export interface Annotation {
-    range: Range
-    item: ItemRef
-}
 export interface Range {
     start: Position
     end: Position
@@ -32,7 +33,4 @@ export interface Range {
 export interface Position {
     line: number
     character: number
-}
-export interface ItemRef {
-    id: string
 }

--- a/lib/ui-react/src/itemChip/ItemChip.story.tsx
+++ b/lib/ui-react/src/itemChip/ItemChip.story.tsx
@@ -3,7 +3,6 @@ import { type Meta, type StoryObj } from '@storybook/react'
 import { ItemChip } from './ItemChip'
 
 const FIXTURE_ITEM: Item = {
-    id: 'css-docs',
     title: '📘 Docs: CSS in client/web',
 }
 

--- a/lib/ui-react/src/itemChip/ItemChip.tsx
+++ b/lib/ui-react/src/itemChip/ItemChip.tsx
@@ -66,8 +66,8 @@ export const ItemChipList: React.FunctionComponent<{
     popoverClassName?: string
 }> = ({ items, className, chipClassName, popoverClassName }) => (
     <div className={clsx(styles.list, className)}>
-        {items.map(item => (
-            <ItemChip key={item.id} item={item} className={chipClassName} popoverClassName={popoverClassName} />
+        {items.map((item, i) => (
+            <ItemChip key={item.url ?? i} item={item} className={chipClassName} popoverClassName={popoverClassName} />
         ))}
     </div>
 )

--- a/lib/ui-standalone/src/itemChip/ItemChip.story.ts
+++ b/lib/ui-standalone/src/itemChip/ItemChip.story.ts
@@ -19,7 +19,6 @@ const meta: Meta = {
 export default meta
 
 const FIXTURE_ITEM: Item = {
-    id: 'css-docs',
     title: '📘 Docs: CSS in client/web',
 }
 

--- a/provider/hello-world/index.test.ts
+++ b/provider/hello-world/index.test.ts
@@ -14,30 +14,28 @@ describe('helloWorld', () => {
                 },
                 {}
             )
-        ).toStrictEqual<AnnotationsResult>({
-            items: [
-                {
-                    id: 'hello-world',
+        ).toStrictEqual<AnnotationsResult>([
+            {
+                item: {
                     title: '✨ Hello, world!',
                     detail: 'From OpenCodeGraph',
                     url: 'https://opencodegraph.org',
                 },
-            ],
-            annotations: [
-                {
-                    item: { id: 'hello-world' },
-                    range: {
-                        start: { line: 0, character: 0 },
-                        end: { line: 0, character: 1 },
-                    },
+                range: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 1 },
                 },
-                {
-                    item: { id: 'hello-world' },
-                    range: {
-                        start: { line: 10, character: 0 },
-                        end: { line: 10, character: 1 },
-                    },
+            },
+            {
+                item: {
+                    title: '✨ Hello, world!',
+                    detail: 'From OpenCodeGraph',
+                    url: 'https://opencodegraph.org',
                 },
-            ],
-        }))
+                range: {
+                    start: { line: 10, character: 0 },
+                    end: { line: 10, character: 1 },
+                },
+            },
+        ]))
 })

--- a/provider/hello-world/index.ts
+++ b/provider/hello-world/index.ts
@@ -20,7 +20,6 @@ const helloWorld: Provider = {
 
     annotations(params: AnnotationsParams, settings: ProviderSettings): AnnotationsResult {
         const item: Item = {
-            id: 'hello-world',
             title: '✨ Hello, world!',
             detail: 'From OpenCodeGraph',
             url: 'https://opencodegraph.org',
@@ -33,15 +32,15 @@ const helloWorld: Provider = {
                 continue
             }
             annotations.push({
+                item,
                 range: {
                     start: { line: i, character: 0 },
                     end: { line: i, character: line.length },
                 },
-                item: { id: item.id },
             })
         }
 
-        return { items: [item], annotations }
+        return annotations
     },
 }
 

--- a/provider/links/index.test.ts
+++ b/provider/links/index.test.ts
@@ -31,31 +31,28 @@ describe('links', () => {
                 },
                 SETTINGS
             )
-        ).toEqual<AnnotationsResult>({
-            items: [
-                {
-                    id: 'https://example.com/foo:Foo:',
+        ).toEqual<AnnotationsResult>([
+            {
+                item: {
                     title: '📘 Docs: Foo',
                     url: 'https://example.com/foo',
                 },
-            ],
-            annotations: [
-                {
-                    item: { id: 'https://example.com/foo:Foo:' },
-                    range: {
-                        start: { line: 0, character: 1 },
-                        end: { line: 0, character: 4 },
-                    },
+                range: {
+                    start: { line: 0, character: 1 },
+                    end: { line: 0, character: 4 },
                 },
-                {
-                    item: { id: 'https://example.com/foo:Foo:' },
-                    range: {
-                        start: { line: 3, character: 1 },
-                        end: { line: 3, character: 4 },
-                    },
+            },
+            {
+                item: {
+                    title: '📘 Docs: Foo',
+                    url: 'https://example.com/foo',
                 },
-            ],
-        })
+                range: {
+                    start: { line: 3, character: 1 },
+                    end: { line: 3, character: 4 },
+                },
+            },
+        ])
     })
 
     test('patterns with capture groups', () => {
@@ -72,24 +69,18 @@ describe('links', () => {
         }
         expect(
             links.annotations({ file: 'file:///a/b.ts', content: 'log.Print(foo, b/a+r)' }, settingsWithCaptureGroups)
-        ).toEqual<AnnotationsResult>({
-            items: [
-                {
-                    id: 'https://example.com/search?q=b%2Fa%2Br:Print foo $3 b/a+r:b/a+r',
+        ).toEqual<AnnotationsResult>([
+            {
+                item: {
                     title: 'Print foo $3 b/a+r',
                     detail: 'b/a+r',
                     url: 'https://example.com/search?q=b%2Fa%2Br',
                 },
-            ],
-            annotations: [
-                {
-                    item: { id: 'https://example.com/search?q=b%2Fa%2Br:Print foo $3 b/a+r:b/a+r' },
-                    range: {
-                        start: { line: 0, character: 0 },
-                        end: { line: 0, character: 21 },
-                    },
+                range: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 21 },
                 },
-            ],
-        })
+            },
+        ])
     })
 })

--- a/provider/links/index.ts
+++ b/provider/links/index.ts
@@ -4,7 +4,6 @@ import {
     type AnnotationsResult,
     type CapabilitiesParams,
     type CapabilitiesResult,
-    type Item,
     type Provider,
     type Range,
 } from '@opencodegraph/provider'
@@ -79,14 +78,8 @@ const links: Provider<Settings> = {
             matchPath: matchGlob(path),
         }))
 
-        const result: AnnotationsResult = {
-            items: [],
-            annotations: [],
-        }
-        const hasItem = (id: string): boolean => result.items.some(item => item.id === id)
-
         const lines = params.content.split(/\r?\n/)
-
+        const anns: AnnotationsResult = []
         for (const { title, url, description, type, matchPath, pattern } of compiledPatterns || []) {
             if (!matchPath(new URL(params.file).pathname)) {
                 continue
@@ -94,30 +87,18 @@ const links: Provider<Settings> = {
 
             const ranges = matchResults(pattern, lines)
             for (const { range, groups } of ranges) {
-                const item: Item = {
-                    id: '',
-                    title: interpolate(title, groups),
-                    detail: description ? interpolate(description, groups) : undefined,
-                    url: interpolate(url, groups),
-                }
-                item.id = `${item.url}:${item.title}:${item.detail || ''}`
-
-                if (type === 'docs') {
-                    item.title = `📘 Docs: ${item.title}`
-                }
-
-                result.annotations.push({
-                    item: { id: item.id },
+                anns.push({
+                    item: {
+                        title: `${type === 'docs' ? '📘 Docs: ' : ''}${interpolate(title, groups)}`,
+                        detail: description ? interpolate(description, groups) : undefined,
+                        url: interpolate(url, groups),
+                    },
                     range,
                 })
-
-                if (!hasItem(item.id)) {
-                    result.items.push(item)
-                }
             }
         }
 
-        return result
+        return anns
     },
 }
 

--- a/provider/prometheus/index.test.ts
+++ b/provider/prometheus/index.test.ts
@@ -34,23 +34,17 @@ var histogram = promauto.NewHistogram(prometheus.HistogramOpts{
                 },
                 SETTINGS
             )
-        ).toEqual<AnnotationsResult>({
-            items: [
-                {
-                    id: 'random_numbers',
+        ).toEqual<AnnotationsResult>([
+            {
+                item: {
                     title: '📟 Prometheus metric: random_numbers',
                     url: 'https://example.com/?q=random_numbers',
                 },
-            ],
-            annotations: [
-                {
-                    item: { id: 'random_numbers' },
-                    range: {
-                        start: { line: 2, character: 14 },
-                        end: { line: 2, character: 28 },
-                    },
+                range: {
+                    start: { line: 2, character: 14 },
+                    end: { line: 2, character: 28 },
                 },
-            ],
-        })
+            },
+        ])
     })
 })

--- a/provider/prometheus/index.ts
+++ b/provider/prometheus/index.ts
@@ -4,7 +4,6 @@ import {
     type AnnotationsResult,
     type CapabilitiesParams,
     type CapabilitiesResult,
-    type Item,
     type Position,
     type Provider,
     type Range,
@@ -75,12 +74,7 @@ const prometheus: Provider<Settings> = {
 
         const positionCalculator = createFilePositionCalculator(params.content)
 
-        const result: AnnotationsResult = {
-            items: [],
-            annotations: [],
-        }
-        const hasItem = (id: string): boolean => result.items.some(item => item.id === id)
-
+        const anns: AnnotationsResult = []
         for (const { matchPath, pattern, urlTemplate } of compiledPatterns || []) {
             if (!matchPath(new URL(params.file).pathname)) {
                 continue
@@ -88,25 +82,16 @@ const prometheus: Provider<Settings> = {
 
             const ranges = matchResults(pattern, params.content, positionCalculator)
             for (const { range, metricName } of ranges) {
-                const item: Item = {
-                    id: '',
-                    title: `📟 Prometheus metric: ${metricName}`,
-                    url: urlTemplate.replaceAll('$1', metricName),
-                }
-                item.id = metricName
-
-                result.annotations.push({
-                    item: { id: item.id },
+                anns.push({
+                    item: {
+                        title: `📟 Prometheus metric: ${metricName}`,
+                        url: urlTemplate.replaceAll('$1', metricName),
+                    },
                     range,
                 })
-
-                if (!hasItem(item.id)) {
-                    result.items.push(item)
-                }
             }
         }
-
-        return result
+        return anns
     },
 }
 

--- a/provider/storybook/index.test.ts
+++ b/provider/storybook/index.test.ts
@@ -51,10 +51,9 @@ export const Bar: Story = {}
                     },
                     SETTINGS
                 )
-            ).toEqual<AnnotationsResult>({
-                items: [
-                    {
-                        id: 'Foo:0',
+            ).toEqual<AnnotationsResult>([
+                {
+                    item: {
                         title: '🖼️ Storybook: a/b/Foo',
                         url: 'https://main--abc123.chromatic.com/?path=%2Fstory%2Fa-b--foo',
                         image: {
@@ -64,29 +63,22 @@ export const Bar: Story = {}
                             height: 300,
                         },
                     },
-                    {
-                        id: 'Bar:1',
+                    range: {
+                        start: { line: 5, character: 13 },
+                        end: { line: 5, character: 16 },
+                    },
+                },
+                {
+                    item: {
                         title: '🖼️ Storybook: a/b/Bar',
                         url: 'https://main--abc123.chromatic.com/?path=%2Fstory%2Fa-b--bar',
                     },
-                ],
-                annotations: [
-                    {
-                        item: { id: 'Foo:0' },
-                        range: {
-                            start: { line: 5, character: 13 },
-                            end: { line: 5, character: 16 },
-                        },
+                    range: {
+                        start: { line: 7, character: 13 },
+                        end: { line: 7, character: 16 },
                     },
-                    {
-                        item: { id: 'Bar:1' },
-                        range: {
-                            start: { line: 7, character: 13 },
-                            end: { line: 7, character: 16 },
-                        },
-                    },
-                ],
-            })
+                },
+            ])
         })
     })
 })

--- a/provider/storybook/index.ts
+++ b/provider/storybook/index.ts
@@ -3,7 +3,6 @@ import {
     type AnnotationsResult,
     type CapabilitiesParams,
     type CapabilitiesResult,
-    type Item,
     type ItemImage,
     type Provider,
     type Range,
@@ -40,10 +39,10 @@ const storybook: Provider<Settings> = {
     },
 
     async annotations(params: AnnotationsParams, settings: Settings): Promise<AnnotationsResult> {
-        const result: AnnotationsResult = { items: [], annotations: [] }
+        const anns: AnnotationsResult = []
 
         if (!settings.storybookUrl) {
-            return result
+            return anns
         }
 
         const contentLines = params.content.split(/\r?\n/)
@@ -59,17 +58,12 @@ const storybook: Provider<Settings> = {
                 for (const [i, story] of matches.entries()) {
                     const storyName = getStoryNameAlias(story, params.content)
                     const storyURL = chromaticStoryURL(component, storyName, settings)
-                    const item: Item = {
-                        id: `${story}:${i}`,
-                        title: `🖼️ Storybook: ${component}/${storyName}`,
-                        url: storyURL,
-                    }
-
-                    item.image = await getImagePreview(storyURL)
-
-                    result.items.push(item)
-                    result.annotations.push({
-                        item: { id: item.id },
+                    anns.push({
+                        item: {
+                            title: `🖼️ Storybook: ${component}/${storyName}`,
+                            url: storyURL,
+                            image: await getImagePreview(storyURL),
+                        },
                         range: ranges[i],
                     })
                 }
@@ -87,24 +81,19 @@ const storybook: Provider<Settings> = {
                 if (storyTitle) {
                     const story = 'Default'
                     const storyURL = chromaticStoryURL(storyTitle, story, settings)
-                    const item: Item = {
-                        id: `${storyTitle}:${i}`,
-                        title: `🖼️ Storybook: ${storyTitle}`,
-                        url: storyURL,
-                    }
-
-                    item.image = await getImagePreview(storyURL)
-
-                    result.items.push(item)
-                    result.annotations.push({
-                        item: { id: item.id },
+                    anns.push({
+                        item: {
+                            title: `🖼️ Storybook: ${storyTitle}`,
+                            url: storyURL,
+                            image: await getImagePreview(storyURL),
+                        },
                         range: ranges[i],
                     })
                 }
             }
         }
 
-        return result
+        return anns
     },
 }
 

--- a/web/content/docs/protocol.mdx
+++ b/web/content/docs/protocol.mdx
@@ -81,7 +81,7 @@ interface Selector {
 
 ### Annotations
 
-The annotations request is sent by the client to the provider to fetch a list of annotations and items for a file.
+The annotations request is sent by the client to the provider to fetch a list of annotations for a file.
 
 **Request:** `{ method: "annotations", params: AnnotationsParams, settings?: object }`
 
@@ -98,17 +98,10 @@ interface AnnotationsParams {
 **Response:** `{ result: AnnotationsResult }` or `{ error: { code, integer, data? } }`
 
 ```typescript
-interface AnnotationsResult {
-  /** Items that contain information relevant to the file. */
-  items: Item[]
-
-  /** Annotations that attach items to specific ranges in the file. */
-  annotations: Annotation[]
-}
+/** Annotations that attach items to specific ranges in the file. */
+type AnnotationsResult = Annotation[]
 
 interface Item {
-  id: string
-
   title: string
 
   /** An external link with more information. */
@@ -120,8 +113,8 @@ interface Item {
 }
 
 interface Annotation {
-  /** The item (referenced by its `Item.id`). */
-  item: { id: string }
+  /** The item. */
+  item: Item
 
   /** The range in the file that the item is relevant to. */
   range: { start: Position; end: Position }


### PR DESCRIPTION
Now, providers just return `Annotation[]` from their `annotations` method. Items no longer have an `id`. It turned out to not be useful to give items an `id` because items were not often reused for multiple ranges in a file.