### PR TITLE
remove readme mention of links provider preview setting

### DIFF
--- a/provider/links/README.md
+++ b/provider/links/README.md
@@ -84,9 +84,6 @@ interface LinkPattern {
   /** The type of link (if applicable), which may affect the appearance. */
   type?: 'docs'
 
-  /** Whether to show a preview of the URL on hover. */
-  preview?: boolean
-
   /** Glob pattern matching the file URIs to annotate. */
   path: string
 


### PR DESCRIPTION
This was made a noop by https://github.com/sourcegraph/opencodegraph/pull/9.